### PR TITLE
[INTERNAL] housecleaning

### DIFF
--- a/lib/hedwig_flowdock.ex
+++ b/lib/hedwig_flowdock.ex
@@ -26,10 +26,6 @@ defmodule Hedwig.Adapters.Flowdock do
     GenServer.cast(r_conn, {:send_message, flowdock_message(msg)})
   end
 
-  def handle_cast({:assign_rest_conn, r_conn}, state) do
-    {:noreply, %{state | rest_conn: r_conn}}
-  end
-
   def handle_cast({:reply, %{user: user, text: text} = msg}, %{rest_conn: r_conn} = state) do
     msg = %{msg | text: "@#{user.name}: #{text}"}
 
@@ -65,13 +61,14 @@ defmodule Hedwig.Adapters.Flowdock do
     {:noreply, state}
   end
 
-  def handle_cast({:flows, flows}, state) do
+  def handle_call({:flows, flows}, _from, state) do
     new_flows = reduce(flows, state.flows)
 
-    {:noreply, %{state | flows: new_flows}}
+    {:reply, nil, %{state | flows: new_flows}}
   end
-  def handle_cast({:users, users}, state) do
-    {:noreply, %{state | users: reduce(users, state.users)}}
+
+  def handle_call({:users, users}, _from, state) do
+    {:reply, nil, %{state | users: reduce(users, state.users)}}
   end
 
   def handle_info(:connection_ready, %{robot: robot} = state) do

--- a/lib/hedwig_flowdock.ex
+++ b/lib/hedwig_flowdock.ex
@@ -24,8 +24,16 @@ defmodule Hedwig.Adapters.Flowdock do
     {:ok, %State{conn: s_conn, rest_conn: r_conn, opts: opts, robot: robot}}
   end
 
-  def handle_cast({:send, msg}, %{rest_conn: r_conn} = _state) do
+  def handle_cast({:send, msg}, %{rest_conn: r_conn} = state) do
     GenServer.cast(r_conn, {:send_message, flowdock_message(msg)})
+
+    {:noreply, state}
+  end
+
+  def handle_cast({:send_raw, msg}, %{rest_conn: r_conn} = state) do
+    GenServer.cast(r_conn, {:send_message, msg})
+
+    {:noreply, state}
   end
 
   def handle_cast({:reply, %{user: user, text: text} = msg}, %{rest_conn: r_conn} = state) do

--- a/lib/hedwig_flowdock.ex
+++ b/lib/hedwig_flowdock.ex
@@ -82,6 +82,10 @@ defmodule Hedwig.Adapters.Flowdock do
     {:reply, nil, new_state}
   end
 
+  def handle_call({:robot_name}, _from, %{opts: opts} = state) do
+    {:reply, opts[:name], state}
+  end
+
   def handle_info(:connection_ready, %{robot: robot} = state) do
     Hedwig.Robot.after_connect(robot)
     {:noreply, state}

--- a/lib/hedwig_flowdock/rest_connection.ex
+++ b/lib/hedwig_flowdock/rest_connection.ex
@@ -4,6 +4,7 @@ defmodule Hedwig.Adapters.Flowdock.RestConnection do
   require Logger
 
   @timeout 5_000
+  @ssl_port 443
   @endpoint "api.flowdock.com"
 
   defstruct conn: nil,
@@ -20,13 +21,13 @@ defmodule Hedwig.Adapters.Flowdock.RestConnection do
   ### PUBLIC API ###
 
   def start_link(opts) do
-    %URI{host: host, port: port, path: path} =
+    %URI{host: host, path: path} =
       URI.parse(opts[:endpoint] || @endpoint)
 
     opts =
       opts
       |> Keyword.put(:host, host)
-      |> Keyword.put(:port, 443)
+      |> Keyword.put(:port, @ssl_port)
       |> Keyword.put(:path, path)
       |> Keyword.put(:owner, self())
 

--- a/lib/hedwig_flowdock/rest_connection.ex
+++ b/lib/hedwig_flowdock/rest_connection.ex
@@ -58,8 +58,8 @@ defmodule Hedwig.Adapters.Flowdock.RestConnection do
         receive do
           {:gun_up, ^conn, :http} ->
             new_state = %{state | conn: conn}
-            connect(:users, new_state)
             connect(:flows, new_state)
+            connect(:users, new_state)
         after @timeout ->
           Logger.error "Unable to connect"
 

--- a/lib/hedwig_flowdock/rest_connection.ex
+++ b/lib/hedwig_flowdock/rest_connection.ex
@@ -79,7 +79,7 @@ defmodule Hedwig.Adapters.Flowdock.RestConnection do
     case :gun.await_body(conn, ref) do
       {:ok, body} ->
         decoded = Poison.decode!(body)
-        GenServer.cast(owner, {:users, decoded})
+        GenServer.call(owner, {:users, decoded})
 
         {:ok, state}
       {:error, _} = error ->
@@ -96,9 +96,8 @@ defmodule Hedwig.Adapters.Flowdock.RestConnection do
     case :gun.await_body(conn, ref) do
       {:ok, body} ->
         decoded = Poison.decode!(body)
-        GenServer.cast(s_conn, {:flows, decoded})
-        GenServer.cast(owner, {:flows, decoded})
-
+        GenServer.call(s_conn, {:flows, decoded})
+        GenServer.call(owner, {:flows, decoded})
         {:ok, state}
       {:error, _} = error ->
         {:backoff, @timeout, state}

--- a/lib/hedwig_flowdock/streaming_connection.ex
+++ b/lib/hedwig_flowdock/streaming_connection.ex
@@ -102,7 +102,7 @@ defmodule Hedwig.Adapters.Flowdock.StreamingConnection do
 
   def handle_call({:flows, flows}, _from, %{owner: owner} = state) do
     # pull flows into filter here
-    query = "filter=#{parameterize_flows(flows)}"
+    query = "filter=#{parameterize_flows(flows)}&active=true&user=1"
     {:reply, {}, %{state | query: query}}
   end
 

--- a/lib/hedwig_flowdock/streaming_connection.ex
+++ b/lib/hedwig_flowdock/streaming_connection.ex
@@ -100,10 +100,10 @@ defmodule Hedwig.Adapters.Flowdock.StreamingConnection do
   def handle_info({:gun_response, _, _, _, _, _}, state), do: {:noreply, state}
 
 
-  def handle_cast({:flows, flows}, %{owner: owner} = state) do
+  def handle_call({:flows, flows}, _from, %{owner: owner} = state) do
     # pull flows into filter here
     query = "filter=#{parameterize_flows(flows)}"
-    {:noreply, %{state | query: query}}
+    {:reply, {}, %{state | query: query}}
   end
 
   def handle_info({:gun_up, conn, :http}, state) do

--- a/lib/hedwig_flowdock/streaming_connection.ex
+++ b/lib/hedwig_flowdock/streaming_connection.ex
@@ -7,13 +7,15 @@ defmodule Hedwig.Adapters.Flowdock.StreamingConnection do
   @endpoint "stream.flowdock.com"
 
   defstruct conn: nil,
-            host: nil,
-            path: nil,
-            port: nil,
-            ref: nil,
-            token: nil,
-            query: nil,
-            owner: nil
+    host: nil,
+    path: nil,
+    port: nil,
+    ref: nil,
+    token: nil,
+    username: nil,
+    password: nil,
+    query: nil,
+    owner: nil
 
   ### PUBLIC API ###
 
@@ -59,8 +61,13 @@ defmodule Hedwig.Adapters.Flowdock.StreamingConnection do
     end
   end
 
-  def connect(:stream_start, %{conn: conn, query: query, token: token} = state) do
-    encoded_pw = Base.encode64(token)
+  def connect(:stream_start, %{conn: conn, query: query, token: token, password: password, username: username} = state) do
+    auth_string = if (password && username) do
+      "#{password}:#{username}"
+    else
+      token
+    end
+    encoded_pw = Base.encode64(auth_string)
     headers = [{"authorization", "Basic #{encoded_pw}"}, {"connection", "keep-alive"}]
     ref = :gun.get(conn, to_char_list("/flows?#{query}"), headers)
 

--- a/lib/hedwig_flowdock/streaming_connection.ex
+++ b/lib/hedwig_flowdock/streaming_connection.ex
@@ -15,7 +15,8 @@ defmodule Hedwig.Adapters.Flowdock.StreamingConnection do
     username: nil,
     password: nil,
     query: nil,
-    owner: nil
+    owner: nil,
+    flows: nil
 
   ### PUBLIC API ###
 
@@ -29,6 +30,7 @@ defmodule Hedwig.Adapters.Flowdock.StreamingConnection do
       |> Keyword.put(:port, 443)
       |> Keyword.put(:path, path)
       |> Keyword.put(:owner, self())
+      |> Keyword.put(:query, "filter=#{parameterize_flows(opts[:flows])}&active=true&user=1")
 
     initial_state = struct(__MODULE__, opts)
 
@@ -98,13 +100,6 @@ defmodule Hedwig.Adapters.Flowdock.StreamingConnection do
   end
 
   def handle_info({:gun_response, _, _, _, _, _}, state), do: {:noreply, state}
-
-
-  def handle_call({:flows, flows}, _from, %{owner: owner} = state) do
-    # pull flows into filter here
-    query = "filter=#{parameterize_flows(flows)}&active=true&user=1"
-    {:reply, {}, %{state | query: query}}
-  end
 
   def handle_info({:gun_up, conn, :http}, state) do
     {:noreply, %{state | conn: conn}}

--- a/lib/hedwig_flowdock/streaming_connection.ex
+++ b/lib/hedwig_flowdock/streaming_connection.ex
@@ -4,6 +4,7 @@ defmodule Hedwig.Adapters.Flowdock.StreamingConnection do
   require Logger
 
   @timeout 5_000
+  @ssl_port 443
   @endpoint "stream.flowdock.com"
 
   defstruct conn: nil,
@@ -21,13 +22,13 @@ defmodule Hedwig.Adapters.Flowdock.StreamingConnection do
   ### PUBLIC API ###
 
   def start_link(opts) do
-    %URI{host: host, port: port, path: path} =
+    %URI{host: host, path: path} =
       URI.parse(opts[:endpoint] || @endpoint)
 
     opts =
       opts
       |> Keyword.put(:host, host)
-      |> Keyword.put(:port, 443)
+      |> Keyword.put(:port, @ssl_port)
       |> Keyword.put(:path, path)
       |> Keyword.put(:owner, self())
       |> Keyword.put(:query, "filter=#{parameterize_flows(opts[:flows])}&active=true&user=1")
@@ -43,11 +44,11 @@ defmodule Hedwig.Adapters.Flowdock.StreamingConnection do
 
   ### Connection callbacks ###
 
-  def init(%{token: token, owner: owner} = state) do
+  def init(state) do
     {:connect, :init, state}
   end
 
-  def connect(info, %{host: host, port: port} = state) when info in [:init, :backoff] do
+  def connect(info, %{port: port} = state) when info in [:init, :backoff] do
     case :gun.open(to_char_list(@endpoint), port) do
       {:ok, conn} ->
         receive do
@@ -59,6 +60,7 @@ defmodule Hedwig.Adapters.Flowdock.StreamingConnection do
           {:backoff, @timeout, state}
         end
       {:error, _} = error ->
+        Logger.error inspect(error)
         {:backoff, @timeout, state}
     end
   end
@@ -74,14 +76,15 @@ defmodule Hedwig.Adapters.Flowdock.StreamingConnection do
     ref = :gun.get(conn, to_char_list("/flows?#{query}"), headers)
 
     case :gun.await(conn, ref) do
-      {body, is_fin, status, _headers} ->
+      {_body, _is_fin, _status, _headers} ->
         {:ok, state}
       {:error, _} = error ->
+        Logger.error inspect(error)
         {:backoff, @timeout, state}
     end
   end
 
-  def disconnect({:close, from}, %{conn: conn} = state) do
+  def disconnect({:close, _from}, %{conn: conn} = state) do
     :ok = :gun.close(conn)
 
     {:stop, :normal, %{state | conn: nil,
@@ -105,19 +108,19 @@ defmodule Hedwig.Adapters.Flowdock.StreamingConnection do
     {:noreply, %{state | conn: conn}}
   end
 
-  def handle_info({:gun_down, _conn, :http, _reason, _, _} = msg, state) do
+  def handle_info({:gun_down, _conn, :http, _reason, _, _} = _msg, state) do
     {:disconnect, :reconnect, state}
   end
 
-  def handle_info({:gun_data, conn, ref, is_fin, "\n"}, state) do
+  def handle_info({:gun_data, conn, _ref, _is_fin, "\n"}, state) do
     {:noreply, %{state | conn: conn}}
   end
 
-  def handle_info({:gun_data, conn, ref, is_fin, "\r\n"}, state) do
+  def handle_info({:gun_data, conn, _ref, _is_fin, "\r\n"}, state) do
     {:noreply, %{state | conn: conn}}
   end
 
-  def handle_info({:gun_data, conn, ref, is_fin, data}, %{owner: owner} = state) do
+  def handle_info({:gun_data, conn, _ref, _is_fin, data}, %{owner: owner} = state) do
     Regex.split(~r/\r\n/, data, trim: true)
     |> Enum.map(fn m ->
       decoded = Poison.decode!(m)

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule HedwigFlowdock.Mixfile do
   use Mix.Project
 
-  @version "0.1.0"
+  @version "0.1.1"
 
   def project do
     [


### PR DESCRIPTION
Updates how state is handled internally and (hopefully) makes startup safer by using `call`s rather than casts and crossing my fingers.

There is still a lot of refactoring out in front of this, but this is a good start.
- Adds bot presence to flows it listens to
- Moves users and flows states onto the rest connection rather than passing them up to the main module
- Updates vars with `_` prefix to respect bootup warnings
