### PR TITLE
Sewillia/1.3

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,10 @@
+2017-07-29 Sean Williamson <sean.j.williamson@gmail.com>
+	* Package: Update Hedwig and Hedwig API calls
+
+	* hedwig_flowdock.ex: Modify init to start up a supervisor
+	responsible for maintaining REST and streaming connections to the
+	Flowdock API
+
+	* mix.exs: Bump minor version
+
+	* CHANGELOG: Add a changelog to keep track of all changes

--- a/README.md
+++ b/README.md
@@ -38,7 +38,10 @@ Add `hedwig_flowdock` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
-  [{:hedwig_flowdock, "0.1"}]
+  [
+    {:hedwig, github: "hedwig-im/hedwig"},
+    {:hedwig_flowdock, "0.1"}
+  ]
 end
 ```
 
@@ -46,7 +49,7 @@ Ensure `hedwig_flowdock` is started before your application:
 
 ```elixir
 def application do
-  [applications: [:hedwig_flowdock]]
+  [applications: [:hedwig, :hedwig_flowdock]]
 end
 ```
 

--- a/lib/hedwig_flowdock.ex
+++ b/lib/hedwig_flowdock.ex
@@ -82,8 +82,7 @@ defmodule Hedwig.Adapters.Flowdock do
 
     if msg.text do
       Logger.info("source=" <> msg.user.name <> " " <>
-                  "text="   <> msg.text      <> " " <>
-                  "ref="    <> inspect(msg.ref))
+                  "text='"   <> msg.text      <> "' ")
 
       Hedwig.Robot.handle_in(robot, msg)
     end

--- a/lib/hedwig_flowdock.ex
+++ b/lib/hedwig_flowdock.ex
@@ -64,7 +64,7 @@ defmodule Hedwig.Adapters.Flowdock do
     {:noreply, state}
   end
 
-  def handle_cast({:message, content, flow_id, user, thread_id} = tup, %{robot: robot} = state) do
+  def handle_cast({:message, content, flow_id, user, thread_id}, %{robot: robot} = state) do
     msg = %Hedwig.Message{
       ref: make_ref(),
       room: flow_id,

--- a/lib/hedwig_flowdock.ex
+++ b/lib/hedwig_flowdock.ex
@@ -81,9 +81,6 @@ defmodule Hedwig.Adapters.Flowdock do
     }
 
     if msg.text do
-      Logger.info("source=" <> msg.user.name <> " " <>
-                  "text='"   <> msg.text      <> "' ")
-
       Hedwig.Robot.handle_in(robot, msg)
     end
     {:noreply, state}

--- a/lib/hedwig_flowdock/connection_supervisor.ex
+++ b/lib/hedwig_flowdock/connection_supervisor.ex
@@ -1,0 +1,21 @@
+defmodule Hedwig.Adapters.Flowdock.ConnectionSupervisor do
+  use Supervisor
+  import Supervisor.Spec
+
+  @supervisor_name :hedwig_flowdock_connection_supervisor
+
+  alias Hedwig.Adapters.Flowdock.StreamingConnection, as: SC
+  alias Hedwig.Adapters.Flowdock.RestConnection, as: RC
+
+  def start_link(opts) do
+    Supervisor.start_link(__MODULE__, [opts], name: @supervisor_name)
+  end
+
+  def init(options) do
+    children = [supervisor(Registry, [:unique, FlowdockConnectionRegistry]),
+                supervisor(RC, options),
+                supervisor(SC, options)
+               ]
+    supervise(children, strategy: :one_for_one)
+  end
+end

--- a/lib/hedwig_flowdock/rest_connection.ex
+++ b/lib/hedwig_flowdock/rest_connection.ex
@@ -54,6 +54,10 @@ defmodule Hedwig.Adapters.Flowdock.RestConnection do
     GenServer.call(pid(), :users)
   end
 
+  def flows do
+    GenServer.call(pid(), :flows)
+  end
+
   def pid do
     [{pid, _}] = Registry.lookup(FlowdockConnectionRegistry, :rest_connection)
     pid

--- a/lib/hedwig_flowdock/rest_connection.ex
+++ b/lib/hedwig_flowdock/rest_connection.ex
@@ -131,7 +131,6 @@ defmodule Hedwig.Adapters.Flowdock.RestConnection do
     robot_name = Hedwig.Adapters.Flowdock.robot_name(pid)
     user = Enum.find(users, fn u -> u["nick"] == robot_name end)
 
-    user |> inspect |> Logger.info
     {mega, secs, _} = :erlang.timestamp()
     last_activity = mega*1000000 + secs
 

--- a/lib/hedwig_flowdock/streaming_connection.ex
+++ b/lib/hedwig_flowdock/streaming_connection.ex
@@ -1,6 +1,8 @@
 defmodule Hedwig.Adapters.Flowdock.StreamingConnection do
   use Connection
 
+  alias Hedwig.Adapters.Flowdock.RestConnection, as: RC
+
   require Logger
 
   @timeout 5_000
@@ -25,8 +27,7 @@ defmodule Hedwig.Adapters.Flowdock.StreamingConnection do
     %URI{host: host, path: path} =
       URI.parse(opts[:endpoint] || @endpoint)
 
-    [{r_conn, _}] = Registry.lookup(FlowdockConnectionRegistry, :rest_connection)
-    flows = GenServer.call(r_conn, :flows)
+    flows = RC.flows
     opts =
       opts
       |> Keyword.put(:host, host)
@@ -45,6 +46,11 @@ defmodule Hedwig.Adapters.Flowdock.StreamingConnection do
 
   def streaming_name do
     {:via, Registry, {FlowdockConnectionRegistry, :streaming_connection}}
+  end
+
+  def pid do
+    [{pid, _}] = Registry.lookup(FlowdockConnectionRegistry, :streaming_connection)
+    pid
   end
 
   def close(pid) do

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule HedwigFlowdock.Mixfile do
   use Mix.Project
 
-  @version "0.1.2"
+  @version "0.1.3"
 
   def project do
     [


### PR DESCRIPTION
* Removes reliance on explicit linked processes in favor of a supervisor
* Upgrades Hedwig

This has been a very long time coming. I have wanted to remove the `start_link` calls forever. I think the use of a `Registry` is overkill, but that can be addressed at a later time.